### PR TITLE
Add a github workflow for testing with pytest.

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,23 @@
+name: Python package
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.6
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.6
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Test with pytest
+      run: |
+        pip install pytest
+        pytest


### PR DESCRIPTION
Fixes and closes #4. See the [workflow in the github UI](https://github.com/open-covid-data/mvp-notes-and-ideas/actions).

I didn't use the dependency cache for the python packages as it only took a few seconds to fetch. We can revisit that choice if needed.