### PR TITLE
Properly type the columns returned when reading the spreadsheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,3 @@ This command creates the folder `ocd-env` if it doesn't exist. You don't need to
 ```console
     $ deactivate
 ```
-

--- a/sheet_cleaner/constants.py
+++ b/sheet_cleaner/constants.py
@@ -24,3 +24,28 @@ rgx_country    = anchor_wrap(boolean_or(["[A-Z]{1}[a-z]+(\\s[A-Z]{1}[a-z]+)*", n
 rgx_geo_res    = anchor_wrap(boolean_or(["point", "admin[0123]{0,1}", na_string, rgx_empty]))
 rgx_date       = anchor_wrap(boolean_or(date_patterns+[na_string, rgx_empty]))
 rgx_lives_in_wuhan = anchor_wrap(boolean_or(["yes", "no", rgx_na_value, rgx_empty]))
+
+column_to_type = {
+    "age": "string",
+    "sex": "string",
+    "city": "string",
+    "province": "string",
+    "country": "string",
+    "date_onset_symptoms": "string",
+    "date_admission_hospital": "string",
+    "date_confirmation": "string",
+    "symptoms": "string",
+    # Should be bool really but lot of info is on business trips to Wuhan
+    # etc, better kept as a string.
+    "lives_in_Wuhan": "string",
+    "travel_history_dates": "string",
+    "travel_history_location": "string",
+    "additional_information": "string",
+    "chronic_disease_binary": "bool",
+    "chronic_disease": "string",
+    "source": "string",
+    "outcome": "string",
+    "date_death_or_discharge": "string",
+    "notes_for_discussion": "string",
+    "travel_history_binary": "bool",
+}

--- a/sheet_cleaner/functions.py
+++ b/sheet_cleaner/functions.py
@@ -76,7 +76,29 @@ def values2dataframe(values: list) -> pd.DataFrame:
         if len(d) < ncols:
             extension = ['']*(ncols-len(d))
             d.extend(extension)
-    data    = pd.DataFrame(data=data, columns=columns)
+    data  = pd.DataFrame(data=data, columns=columns)
+    data = data.astype({
+        "age": "string",
+        "sex": "string",
+        "city": "string",
+        "province": "string",
+        "country": "string",
+        "date_onset_symptoms": "string",
+        "date_admission_hospital": "string",
+        "date_confirmation": "string",
+        "symptoms": "string",
+        "lives_in_Wuhan": "bool",
+        "travel_history_dates": "string",
+        "travel_history_location": "string",
+        "additional_information": "string",
+        "chronic_disease_binary": "bool",
+        "chronic_disease": "string",
+        "source": "string",
+        "outcome": "string",
+        "date_death_or_discharge": "string",
+        "notes_for_discussion": "string",
+        "travel_history_binary": "bool",
+    })
     data['row'] = list(range(2, len(data)+2)) # keeping row number (+1 for 1 indexing +1 for column headers in sheet)
     data['row'] = data['row'].astype(str)
         

--- a/sheet_cleaner/functions.py
+++ b/sheet_cleaner/functions.py
@@ -87,7 +87,8 @@ def values2dataframe(values: list) -> pd.DataFrame:
         "date_admission_hospital": "string",
         "date_confirmation": "string",
         "symptoms": "string",
-        "lives_in_Wuhan": "bool",
+        # Should be bool but lot of info is on business trips to Wuhan etc, better kept as a string.
+        "lives_in_Wuhan": "string",
         "travel_history_dates": "string",
         "travel_history_location": "string",
         "additional_information": "string",
@@ -208,12 +209,7 @@ def generate_error_tables(data):
         row = r.copy()
         fix = False
         col = row['column']
-        if col == 'sex':
-            test = row['value'].lower().strip() in ['male', 'female', '']
-            if test:
-                fix = row['value'].lower().strip()
-
-        elif col == 'age':
+        if col == 'age':
             test = bool(re.match(rgx_age, row['value'].replace(' ', '')))
             if test:
                 fix = row['value'].replace(' ', '')


### PR DESCRIPTION
Remove the whitespace trimming functionality when generating error reports as we already do this for all string columns now.

Fixes #45.
Fixes #43.